### PR TITLE
enforce limit on tags in converters.form

### DIFF
--- a/index.js
+++ b/index.js
@@ -518,7 +518,7 @@ function ApostropheSchemas(options, callback) {
       }
       //enforce limit if provided, take first N elements
       if (field.options && field.options.limit) {
-        tags = tags.splice(0, field.options.limit-1);
+        tags = tags.slice(0, field.options.limit);
       }
       snippet[field.name] = tags;
       return callback(null);

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -490,7 +490,7 @@ function AposSchemas() {
       return apos.afterYield(callback);
     },
     tags: function(data, name, $field, $el, field, callback) {
-      apos.enableTags(self.findSafe($el, '[data-name="' + name + '"]'), data[name], field.options || {});
+      apos.enableTags(self.findSafe($el, '[data-name="' + name + '"]'), data[name], field || {});
       return apos.afterYield(callback);
     },
     url: function(data, name, $field, $el, field, callback) {


### PR DESCRIPTION
enforce limit on tags if provided
remove unused vars
declare undeclared vars
make JSLint happy
