### PR TITLE
Collapse arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ And then pass it as the `schemas` option to every module that will use it. But t
 
 ### Adding New Properties To Objects Using the Schema
 
-A schema is a simple array of objects specifying information about each field. The `apostrophe-schemass` module provides methods to build schemas, validate submitted data according to a schema, and carry out joins according to a schema. The module also provides browser-side JavaScript and Nunjucks templates to edit an object based on its schema.
+A schema is a simple array of objects specifying information about each field. The `apostrophe-schemas` module provides methods to build schemas, validate submitted data according to a schema, and carry out joins according to a schema. The module also provides browser-side JavaScript and Nunjucks templates to edit an object based on its schema.
 
 Schema objects have intentionally been kept simple so that they can be send to the browser as JSON and interpreted by browser-side JavaScript as well.
 
@@ -188,6 +188,7 @@ This is easy to do with the `array` field type:
   name: 'offices',
   label: 'Offices',
   type: 'array',
+  minimize: true,
   schema: [
     {
       name: 'city',
@@ -214,6 +215,8 @@ This is easy to do with the `array` field type:
 ```
 
 Each `array` has its own `schema`, which supports all of the usual field types. You an even nest an `array` in another `array`.
+
+The `minimize` option of the array field type enables editors to expand or hide fields of an array in order to more easily work with longer lists of items or items with very long schemas.
 
 It's easy to access the resulting information in a page template, such as the `show` template for companies. The array property is... you guessed it... an array! Not hard to iterate over at all:
 

--- a/public/css/array-schemas.less
+++ b/public/css/array-schemas.less
@@ -9,6 +9,8 @@
   .apos-fieldset
   {
     margin-bottom: 1em !important;
+    display: none;
+    &:first-of-type { display: block; }
   }
 
   // &.apos-array-toggle

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -449,9 +449,18 @@ function AposSchemas() {
         $element.removeClass('apos-template');
         addRemoveHandler($element);
         addMoveHandler($element);
-        addOpenHandler($element);
-        // Default state for existing elements is closed
-        toggleOpen($element, self.findSafe($element, '[data-open-item]'), false);
+
+        // If the minimize option is passed to an array schema field, it
+        // will automatically hide all element fields except for the first
+        // one. The other fields will be revealed upon toggling the '+'
+        // button or focussing the first field.
+        if (field.minimize) {
+          addOpenHandler($element);
+          // Default state for existing elements is closed
+          toggleOpen($element, self.findSafe($element, '[data-open-item]'), false);
+        } else {
+          alwaysOpen($element);
+        }
 
         $element.attr('data-id', data[i].id);
 
@@ -469,9 +478,14 @@ function AposSchemas() {
         $elements.prepend($element);
         addRemoveHandler($element);
         addMoveHandler($element);
-        addOpenHandler($element);
-        // Default state for new elements is expanded
-        toggleOpen($element, self.findSafe($element, '[data-open-item]'), true);
+
+        if (field.minimize) {
+          addOpenHandler($element);
+          // Default state for new elements is expanded
+          toggleOpen($element, self.findSafe($element, '[data-open-item]'), true);
+        } else {
+          alwaysOpen($element);
+        }
 
         var element = {};
         _.each(field.schema, function(field) {
@@ -518,10 +532,16 @@ function AposSchemas() {
       function toggleOpen($element, $open, state) {
         var expanded = _.isBoolean(state) ? state : undefined
         $element.toggleClass('apos-array-item--open', expanded);
-        $open.find('i').toggleClass('icon-minus', expanded);
-        $element.find('[data-name]:first-of-type input').first().off().focus(function() {
+        $open.findSafe('i').toggleClass('icon-minus', expanded);
+        $element.findSafe('[data-name]:first-of-type input').first().off().focus(function() {
           toggleOpen($element, $open, true);
         });
+      }
+
+      function alwaysOpen($element) {
+        var $open = self.findSafe($element, '[data-open-item]');
+        toggleOpen($element, self.findSafe($element, '[data-open-item]'), true);
+        $open.hide();
       }
 
     },

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -350,7 +350,11 @@ function AposSchemas() {
       return apos.afterYield(callback);
     },
     boolean: function(data, name, $field, $el, field, callback) {
-      data[name] = $field.val();
+      if (field.checkbox) {
+        data[name] = $field.prop('checked');
+      } else {
+        data[name] = $field.val();
+      }
       // Seems odd but sometimes used to mandate an "I agree" box
       if (field.required && !data[name]) {
         return apos.afterYield(_.partial(callback, 'required'));
@@ -446,6 +450,8 @@ function AposSchemas() {
         addRemoveHandler($element);
         addMoveHandler($element);
         addOpenHandler($element);
+        // Default state for existing elements is closed
+        toggleOpen($element, self.findSafe($element, '[data-open-item]'), false);
 
         $element.attr('data-id', data[i].id);
 
@@ -464,7 +470,8 @@ function AposSchemas() {
         addRemoveHandler($element);
         addMoveHandler($element);
         addOpenHandler($element);
-        toggleOpen($element, self.findSafe($element, '[data-open-item]'));
+        // Default state for new elements is expanded
+        toggleOpen($element, self.findSafe($element, '[data-open-item]'), true);
 
         var element = {};
         _.each(field.schema, function(field) {
@@ -508,9 +515,13 @@ function AposSchemas() {
         });
       }
 
-      function toggleOpen($element, $open) {
-        $element.toggleClass('apos-array-item--open');
-        $open.find('i').toggleClass('icon-minus');
+      function toggleOpen($element, $open, state) {
+        var expanded = _.isBoolean(state) ? state : undefined
+        $element.toggleClass('apos-array-item--open', expanded);
+        $open.find('i').toggleClass('icon-minus', expanded);
+        $element.find('[data-name]:first-of-type input').first().off().focus(function() {
+          toggleOpen($element, $open, true);
+        });
       }
 
     },
@@ -588,7 +599,11 @@ function AposSchemas() {
       return apos.afterYield(callback);
     },
     boolean: function(data, name, $field, $el, field, callback) {
-      $field.val(data[name] ? '1' : '0');
+      if (field.checkbox) {
+        $field.prop('checked', data[name]);
+      } else {
+        $field.val(data[name] ? '1' : '0');
+      }
       return apos.afterYield(callback);
     },
     joinByOne: function(data, name, $field, $el, field, callback) {

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -445,6 +445,7 @@ function AposSchemas() {
         $element.removeClass('apos-template');
         addRemoveHandler($element);
         addMoveHandler($element);
+        addOpenHandler($element);
 
         $element.attr('data-id', data[i].id);
 
@@ -462,6 +463,8 @@ function AposSchemas() {
         $elements.prepend($element);
         addRemoveHandler($element);
         addMoveHandler($element);
+        addOpenHandler($element);
+        toggleOpen($element, self.findSafe($element, '[data-open-item]'));
 
         var element = {};
         _.each(field.schema, function(field) {
@@ -495,6 +498,19 @@ function AposSchemas() {
           }
           return false;
         });
+      }
+
+      function addOpenHandler($element) {
+        var $open = self.findSafe($element, '[data-open-item]');
+        $open.on('click', function() {
+          toggleOpen($element, $(this));
+          return false;
+        });
+      }
+
+      function toggleOpen($element, $open) {
+        $element.toggleClass('apos-array-item--open');
+        $open.find('i').toggleClass('icon-minus');
       }
 
     },

--- a/views/schemaMacros.html
+++ b/views/schemaMacros.html
@@ -64,6 +64,9 @@
                 <div class="apos-modal-tab-title {% if loop.first -%}apos-active{%- endif %}" data-tab="{{ group.name }}"><i class="{{ group.icon }}"></i> {{ group.label }}</div>
               {%- endfor -%}
             </div>
+            {# Helpful when treating tabs as scrolling signposts rather than #}
+            {# showing and hiding divs. -Tom #}
+            <div class="apos-modal-tab-bodies">
         {%- endif -%}
         {{ schemaOpenGroup(fields, field.group, activeGroup) }}
         {%- set lastGroup = field.group -%}
@@ -92,7 +95,10 @@
   {# Nunjucks won't let us just test lastGroup from here due to #}
   {# scoping issues https://github.com/mozilla/nunjucks/issues/166 #}
   {%- if aposFilterNonempty(fields, 'group').length -%}
-    {{ schemaCloseGroup() }}
+      {{ schemaCloseGroup() }}
+      {# apos-modal-tab-bodies #}
+      </div>
+    {# apos-modal-tabs #}
     </div>
   {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
Array items now hide all but their first field by default. The `+`/`-` button allows for expansion or closing of those fields. Focusing the first field results in expanding the item. New items are expanded by default.

@jsumnersmith 